### PR TITLE
Support cuda architecture sm70 and sm75

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Vim
+*.swp

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,10 @@
+import os
 from setuptools import setup, find_packages
+import torch
 from torch.utils import cpp_extension
+
+compute_capability = torch.cuda.get_device_capability()
+cuda_arch = compute_capability[0] * 100 + compute_capability[1] * 10
 
 setup(
     name='torch_int',
@@ -17,7 +22,7 @@ setup(
                              '-lculibos', '-lcudart', '-lcudart_static',
                              '-lrt', '-lpthread', '-ldl', '-L/usr/lib/x86_64-linux-gnu/'],
             extra_compile_args={'cxx': ['-std=c++14', '-O3'],
-                                'nvcc': ['-O3', '-std=c++14', '-U__CUDA_NO_HALF_OPERATORS__', '-U__CUDA_NO_HALF_CONVERSIONS__', '-U__CUDA_NO_HALF2_OPERATORS__']},
+                                'nvcc': ['-O3', '-std=c++14', '-U__CUDA_NO_HALF_OPERATORS__', '-U__CUDA_NO_HALF_CONVERSIONS__', '-U__CUDA_NO_HALF2_OPERATORS__', f'-DCUDA_ARCH={cuda_arch}']},
         ),
     ],
     cmdclass={

--- a/tests/test_linear_kernels.py
+++ b/tests/test_linear_kernels.py
@@ -48,7 +48,6 @@ def test_quant_linear_a8_w8_bfp32_ofp32():
     y_gt = linear(x.float())
     y = linear_a8_w8_bfp32_ofp32(
         x.cuda(), weight.cuda(), bias.cuda(), alpha, beta)
-    print(y.shape)
     ic(torch.allclose(y_gt, y.cpu(), atol=0.5))
 
 

--- a/torch_int/kernels/bmm.cu
+++ b/torch_int/kernels/bmm.cu
@@ -153,7 +153,7 @@ torch::Tensor bmm_s8t_s8n_s8t(torch::Tensor A, torch::Tensor B, float alpha) {
       DefaultGemmCfg::WarpShape, DefaultGemmCfg::InstructionShape,
       EpilogueOp>;
 #elif CUDA_ARCH >= 700
-  using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombinationClamp<
       ElementOutput, 1, ElementAccumulator, ElementComputeEpilogue>;
   using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
       cutlass::arch::OpClassSimt, cutlass::arch::Sm70,
@@ -253,7 +253,7 @@ torch::Tensor bmm_s8t_s8n_s32t(torch::Tensor A, torch::Tensor B) {
       DefaultGemmCfg::WarpShape, DefaultGemmCfg::InstructionShape,
       EpilogueOp>;
 #elif CUDA_ARCH >= 700
-  using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombinationClamp<
       ElementOutput, 1, ElementAccumulator, ElementComputeEpilogue>;
   using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
       cutlass::arch::OpClassSimt, cutlass::arch::Sm70,

--- a/torch_int/kernels/bmm.cu
+++ b/torch_int/kernels/bmm.cu
@@ -52,6 +52,18 @@ torch::Tensor bmm_s8t_s8n_f32t(torch::Tensor A, torch::Tensor B, float alpha) {
       cutlass::arch::Sm75, DefaultGemmCfg::ThreadblockShape,
       DefaultGemmCfg::WarpShape, DefaultGemmCfg::InstructionShape,
       EpilogueOp>;
+#elif CUDA_ARCH >= 700
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+      ElementOutput, 1, ElementAccumulator, ElementComputeEpilogue>;
+  using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
+      cutlass::arch::OpClassSimt, cutlass::arch::Sm70,
+      ElementInputA, ElementInputB, ElementOutput, ElementAccumulator>;
+  using Gemm = cutlass::gemm::device::GemmBatched<
+      ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
+      LayoutOutput, ElementAccumulator, cutlass::arch::OpClassSimt,
+      cutlass::arch::Sm70, DefaultGemmCfg::ThreadblockShape,
+      DefaultGemmCfg::WarpShape, DefaultGemmCfg::InstructionShape,
+      EpilogueOp>;
 #else
   #error "Unsupported cuda arch"
 #endif
@@ -140,6 +152,18 @@ torch::Tensor bmm_s8t_s8n_s8t(torch::Tensor A, torch::Tensor B, float alpha) {
       cutlass::arch::Sm75, DefaultGemmCfg::ThreadblockShape,
       DefaultGemmCfg::WarpShape, DefaultGemmCfg::InstructionShape,
       EpilogueOp>;
+#elif CUDA_ARCH >= 700
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+      ElementOutput, 1, ElementAccumulator, ElementComputeEpilogue>;
+  using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
+      cutlass::arch::OpClassSimt, cutlass::arch::Sm70,
+      ElementInputA, ElementInputB, ElementOutput, ElementAccumulator>;
+  using Gemm = cutlass::gemm::device::GemmBatched<
+      ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
+      LayoutOutput, ElementAccumulator, cutlass::arch::OpClassSimt,
+      cutlass::arch::Sm70, DefaultGemmCfg::ThreadblockShape,
+      DefaultGemmCfg::WarpShape, DefaultGemmCfg::InstructionShape,
+      EpilogueOp>;
 #else
   #error "Unsupported cuda arch"
 #endif
@@ -226,6 +250,18 @@ torch::Tensor bmm_s8t_s8n_s32t(torch::Tensor A, torch::Tensor B) {
       ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
       LayoutOutput, ElementAccumulator, cutlass::arch::OpClassTensorOp,
       cutlass::arch::Sm75, DefaultGemmCfg::ThreadblockShape,
+      DefaultGemmCfg::WarpShape, DefaultGemmCfg::InstructionShape,
+      EpilogueOp>;
+#elif CUDA_ARCH >= 700
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+      ElementOutput, 1, ElementAccumulator, ElementComputeEpilogue>;
+  using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
+      cutlass::arch::OpClassSimt, cutlass::arch::Sm70,
+      ElementInputA, ElementInputB, ElementOutput, ElementAccumulator>;
+  using Gemm = cutlass::gemm::device::GemmBatched<
+      ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
+      LayoutOutput, ElementAccumulator, cutlass::arch::OpClassSimt,
+      cutlass::arch::Sm70, DefaultGemmCfg::ThreadblockShape,
       DefaultGemmCfg::WarpShape, DefaultGemmCfg::InstructionShape,
       EpilogueOp>;
 #else

--- a/torch_int/kernels/bmm.cu
+++ b/torch_int/kernels/bmm.cu
@@ -43,11 +43,14 @@ torch::Tensor bmm_s8t_s8n_f32t(torch::Tensor A, torch::Tensor B, float alpha) {
   using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
       ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
       ElementAccumulator, ElementComputeEpilogue>;
+  using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75,
+      ElementInputA, ElementInputB, ElementOutput, ElementAccumulator>;
   using Gemm = cutlass::gemm::device::GemmBatched<
       ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
       LayoutOutput, ElementAccumulator, cutlass::arch::OpClassTensorOp,
-      cutlass::arch::Sm75, cutlass::gemm::GemmShape<256, 128, 64>,
-      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<8, 8, 16>,
+      cutlass::arch::Sm75, DefaultGemmCfg::ThreadblockShape,
+      DefaultGemmCfg::WarpShape, DefaultGemmCfg::InstructionShape,
       EpilogueOp>;
 #else
   #error "Unsupported cuda arch"
@@ -125,14 +128,17 @@ torch::Tensor bmm_s8t_s8n_s8t(torch::Tensor A, torch::Tensor B, float alpha) {
       cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
       EpilogueOp>;
 #elif CUDA_ARCH >= 750
-  using EpilogueOp = cutlass::epilogue::thread::LinearCombinationClamp<
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
       ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
       ElementAccumulator, ElementComputeEpilogue>;
+  using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75,
+      ElementInputA, ElementInputB, ElementOutput, ElementAccumulator>;
   using Gemm = cutlass::gemm::device::GemmBatched<
       ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
       LayoutOutput, ElementAccumulator, cutlass::arch::OpClassTensorOp,
-      cutlass::arch::Sm75, cutlass::gemm::GemmShape<256, 128, 64>,
-      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<8, 8, 16>,
+      cutlass::arch::Sm75, DefaultGemmCfg::ThreadblockShape,
+      DefaultGemmCfg::WarpShape, DefaultGemmCfg::InstructionShape,
       EpilogueOp>;
 #else
   #error "Unsupported cuda arch"
@@ -213,11 +219,14 @@ torch::Tensor bmm_s8t_s8n_s32t(torch::Tensor A, torch::Tensor B) {
   using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
       ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
       ElementAccumulator, ElementComputeEpilogue>;
+  using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75,
+      ElementInputA, ElementInputB, ElementOutput, ElementAccumulator>;
   using Gemm = cutlass::gemm::device::GemmBatched<
       ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
       LayoutOutput, ElementAccumulator, cutlass::arch::OpClassTensorOp,
-      cutlass::arch::Sm75, cutlass::gemm::GemmShape<256, 128, 64>,
-      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<8, 8, 16>,
+      cutlass::arch::Sm75, DefaultGemmCfg::ThreadblockShape,
+      DefaultGemmCfg::WarpShape, DefaultGemmCfg::InstructionShape,
       EpilogueOp>;
 #else
   #error "Unsupported cuda arch"

--- a/torch_int/kernels/bmm.cu
+++ b/torch_int/kernels/bmm.cu
@@ -29,16 +29,29 @@ torch::Tensor bmm_s8t_s8n_f32t(torch::Tensor A, torch::Tensor B, float alpha) {
   using ElementAccumulator = int32_t;
   using ElementComputeEpilogue = float;
 
+#if CUDA_ARCH >= 800
   using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
       ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
       ElementAccumulator, ElementComputeEpilogue>;
-
   using Gemm = cutlass::gemm::device::GemmBatched<
       ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
       LayoutOutput, ElementAccumulator, cutlass::arch::OpClassTensorOp,
       cutlass::arch::Sm80, cutlass::gemm::GemmShape<256, 128, 64>,
       cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
       EpilogueOp>;
+#elif CUDA_ARCH >= 750
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+      ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+      ElementAccumulator, ElementComputeEpilogue>;
+  using Gemm = cutlass::gemm::device::GemmBatched<
+      ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
+      LayoutOutput, ElementAccumulator, cutlass::arch::OpClassTensorOp,
+      cutlass::arch::Sm75, cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<8, 8, 16>,
+      EpilogueOp>;
+#else
+  #error "Unsupported cuda arch"
+#endif
 
   long long int batch_stride_A = M * K;
   long long int batch_stride_B = N * K;
@@ -101,16 +114,29 @@ torch::Tensor bmm_s8t_s8n_s8t(torch::Tensor A, torch::Tensor B, float alpha) {
   using ElementAccumulator = int32_t;
   using ElementComputeEpilogue = float;
 
+#if CUDA_ARCH >= 800
   using EpilogueOp = cutlass::epilogue::thread::LinearCombinationClamp<
       ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
       ElementAccumulator, ElementComputeEpilogue>;
-
   using Gemm = cutlass::gemm::device::GemmBatched<
       ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
       LayoutOutput, ElementAccumulator, cutlass::arch::OpClassTensorOp,
       cutlass::arch::Sm80, cutlass::gemm::GemmShape<256, 128, 64>,
       cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
       EpilogueOp>;
+#elif CUDA_ARCH >= 750
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombinationClamp<
+      ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+      ElementAccumulator, ElementComputeEpilogue>;
+  using Gemm = cutlass::gemm::device::GemmBatched<
+      ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
+      LayoutOutput, ElementAccumulator, cutlass::arch::OpClassTensorOp,
+      cutlass::arch::Sm75, cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<8, 8, 16>,
+      EpilogueOp>;
+#else
+  #error "Unsupported cuda arch"
+#endif
 
   long long int batch_stride_A = M * K;
   long long int batch_stride_B = N * K;
@@ -173,16 +199,29 @@ torch::Tensor bmm_s8t_s8n_s32t(torch::Tensor A, torch::Tensor B) {
   using ElementAccumulator = int32_t;
   using ElementComputeEpilogue = int32_t;
 
+#if CUDA_ARCH >= 800
   using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
       ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
       ElementAccumulator, ElementComputeEpilogue>;
-
   using Gemm = cutlass::gemm::device::GemmBatched<
       ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
       LayoutOutput, ElementAccumulator, cutlass::arch::OpClassTensorOp,
       cutlass::arch::Sm80, cutlass::gemm::GemmShape<256, 128, 64>,
       cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
       EpilogueOp>;
+#elif CUDA_ARCH >= 750
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombination<
+      ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+      ElementAccumulator, ElementComputeEpilogue>;
+  using Gemm = cutlass::gemm::device::GemmBatched<
+      ElementInputA, LayoutInputA, ElementInputB, LayoutInputB, ElementOutput,
+      LayoutOutput, ElementAccumulator, cutlass::arch::OpClassTensorOp,
+      cutlass::arch::Sm75, cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<8, 8, 16>,
+      EpilogueOp>;
+#else
+  #error "Unsupported cuda arch"
+#endif
 
   long long int batch_stride_A = M * K;
   long long int batch_stride_B = N * K;

--- a/torch_int/kernels/linear.cu
+++ b/torch_int/kernels/linear.cu
@@ -43,6 +43,18 @@ torch::Tensor linear_a8_w8_b32_o32(torch::Tensor input,  // INT8
           ElementAccumulator, ElementComputeEpilogue,
           cutlass::epilogue::thread::ScaleType::NoBetaScaling>,
       cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
+#elif CUDA_ARCH >= 750
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75,
+      cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<8, 8, 16>,
+      cutlass::epilogue::thread::LinearCombination<
+          ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+          ElementAccumulator, ElementComputeEpilogue,
+          cutlass::epilogue::thread::ScaleType::NoBetaScaling>,
+      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 2>;
 #elif CUDA_ARCH >= 700
   using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
       cutlass::arch::OpClassSimt, cutlass::arch::Sm70,
@@ -156,6 +168,17 @@ torch::Tensor linear_a8_w8_b32_o32_with_scaling(torch::Tensor input,  // INT8
           ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
           ElementAccumulator, ElementComputeEpilogue>,
       cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
+#elif CUDA_ARCH >= 750
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75,
+      cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<8, 8, 16>,
+      cutlass::epilogue::thread::LinearCombination<
+          ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+          ElementAccumulator, ElementComputeEpilogue>,
+      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 2>;
 #elif CUDA_ARCH >= 700
   using Gemm = cutlass::gemm::device::Gemm<
       int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
@@ -258,6 +281,17 @@ torch::Tensor linear_a8_w8_bfp32_ofp32(torch::Tensor input,  // INT8
           ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
           ElementAccumulator, ElementComputeEpilogue>,
       cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
+#elif CUDA_ARCH >= 750
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75,
+      cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<8, 8, 16>,
+      cutlass::epilogue::thread::LinearCombination<
+          ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+          ElementAccumulator, ElementComputeEpilogue>,
+      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 2>;
 #elif CUDA_ARCH >= 700
   using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
       cutlass::arch::OpClassSimt, cutlass::arch::Sm70,
@@ -367,6 +401,16 @@ torch::Tensor linear_a8_w8_b8_o8(torch::Tensor input,  // INT8
       cutlass::epilogue::thread::FastLinearCombinationClamp<
           ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value>,
       cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
+#elif CUDA_ARCH >= 750
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75,
+      cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<8, 8, 16>,
+      cutlass::epilogue::thread::FastLinearCombinationClamp<
+          ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value>,
+      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 2>;
 #elif CUDA_ARCH >= 700
   using Gemm = cutlass::gemm::device::Gemm<
       int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
@@ -472,7 +516,6 @@ torch::Tensor linear_relu_a8_w8_b8_o8(torch::Tensor input,  // INT8
       ElementComputeEpilogue // <- data type for alpha in linear combination
                              // function
       >;
-
   using Gemm = cutlass::gemm::device::Gemm<
       int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
       ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
@@ -481,6 +524,27 @@ torch::Tensor linear_relu_a8_w8_b8_o8(torch::Tensor input,  // INT8
       cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
       EpilogueOp, cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
       3>;
+#elif CUDA_ARCH >= 750
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombinationRelu<
+      ElementOutput, // <- data type of output matrix
+      128 / cutlass::sizeof_bits<
+                ElementOutput>::value, // <- this is the number of elements per
+                                       // vectorized memory access. For half
+                                       // precision, it's 8 elements. This
+                                       // becomes the vector width of math
+                                       // instructions in epilogue too
+      ElementAccumulator,              // <- data type of accumulator
+      ElementComputeEpilogue // <- data type for alpha in linear combination
+                             // function
+      >;
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75,
+      cutlass::gemm::GemmShape<256, 128, 64>,
+      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<8, 8, 16>,
+      EpilogueOp, cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
+      2>;
 #elif CUDA_ARCH >= 700
   using EpilogueOp = cutlass::epilogue::thread::LinearCombinationRelu<
       ElementOutput, 1, ElementAccumulator, ElementComputeEpilogue>;

--- a/torch_int/kernels/linear.cu
+++ b/torch_int/kernels/linear.cu
@@ -31,6 +31,7 @@ torch::Tensor linear_a8_w8_b32_o32(torch::Tensor input,  // INT8
   using LayoutInputB = cutlass::layout::ColumnMajor;
   using LayoutOutput = cutlass::layout::RowMajor;
 
+#if CUDA_ARCH >= 800
   using Gemm = cutlass::gemm::device::Gemm<
       int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
       ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
@@ -42,6 +43,22 @@ torch::Tensor linear_a8_w8_b32_o32(torch::Tensor input,  // INT8
           ElementAccumulator, ElementComputeEpilogue,
           cutlass::epilogue::thread::ScaleType::NoBetaScaling>,
       cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
+#elif CUDA_ARCH >= 700
+  using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
+      cutlass::arch::OpClassSimt, cutlass::arch::Sm70,
+      ElementInputA, ElementInputB, ElementOutput, ElementAccumulator>;
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassSimt, cutlass::arch::Sm70,
+      DefaultGemmCfg::ThreadblockShape, DefaultGemmCfg::WarpShape,
+      DefaultGemmCfg::InstructionShape,
+      cutlass::epilogue::thread::LinearCombination<
+          ElementOutput, 1, ElementAccumulator, ElementComputeEpilogue,
+          cutlass::epilogue::thread::ScaleType::NoBetaScaling>>;
+#else
+  #error "Unsupported cuda arch"
+#endif
 
   auto input_size = cutlass::MatrixCoord(M, K);
   auto weight_size = cutlass::MatrixCoord(K, N);
@@ -128,6 +145,7 @@ torch::Tensor linear_a8_w8_b32_o32_with_scaling(torch::Tensor input,  // INT8
   using LayoutInputB = cutlass::layout::ColumnMajor;
   using LayoutOutput = cutlass::layout::RowMajor;
 
+#if CUDA_ARCH >= 800
   using Gemm = cutlass::gemm::device::Gemm<
       int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
       ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
@@ -138,6 +156,14 @@ torch::Tensor linear_a8_w8_b32_o32_with_scaling(torch::Tensor input,  // INT8
           ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
           ElementAccumulator, ElementComputeEpilogue>,
       cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
+#elif CUDA_ARCH >= 700
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassSimt, cutlass::arch::Sm70>;
+#else
+  #error "Unsupported cuda arch"
+#endif
 
   auto input_size = cutlass::MatrixCoord(M, K);
   auto weight_size = cutlass::MatrixCoord(K, N);
@@ -221,6 +247,7 @@ torch::Tensor linear_a8_w8_bfp32_ofp32(torch::Tensor input,  // INT8
   using LayoutInputB = cutlass::layout::ColumnMajor;
   using LayoutOutput = cutlass::layout::RowMajor;
 
+#if CUDA_ARCH >= 800
   using Gemm = cutlass::gemm::device::Gemm<
       int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
       ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
@@ -231,6 +258,21 @@ torch::Tensor linear_a8_w8_bfp32_ofp32(torch::Tensor input,  // INT8
           ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
           ElementAccumulator, ElementComputeEpilogue>,
       cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
+#elif CUDA_ARCH >= 700
+  using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
+      cutlass::arch::OpClassSimt, cutlass::arch::Sm70,
+      ElementInputA, ElementInputB, ElementOutput, ElementAccumulator>;
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassSimt, cutlass::arch::Sm70,
+      DefaultGemmCfg::ThreadblockShape, DefaultGemmCfg::WarpShape,
+      DefaultGemmCfg::InstructionShape,
+      cutlass::epilogue::thread::LinearCombination<
+          ElementOutput, 1, ElementAccumulator, ElementComputeEpilogue>>;
+#else
+  #error "Unsupported cuda arch"
+#endif
 
   auto input_size = cutlass::MatrixCoord(M, K);
   auto weight_size = cutlass::MatrixCoord(K, N);
@@ -315,6 +357,7 @@ torch::Tensor linear_a8_w8_b8_o8(torch::Tensor input,  // INT8
   using LayoutInputB = cutlass::layout::ColumnMajor;
   using LayoutOutput = cutlass::layout::RowMajor;
 
+#if CUDA_ARCH >= 800
   using Gemm = cutlass::gemm::device::Gemm<
       int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
       ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
@@ -324,6 +367,14 @@ torch::Tensor linear_a8_w8_b8_o8(torch::Tensor input,  // INT8
       cutlass::epilogue::thread::FastLinearCombinationClamp<
           ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value>,
       cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
+#elif CUDA_ARCH >= 700
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassSimt, cutlass::arch::Sm70>;
+#else
+  #error "Unsupported cuda arch"
+#endif
 
   auto input_size = cutlass::MatrixCoord(M, K);
   auto weight_size = cutlass::MatrixCoord(K, N);
@@ -408,6 +459,7 @@ torch::Tensor linear_relu_a8_w8_b8_o8(torch::Tensor input,  // INT8
   using LayoutInputB = cutlass::layout::ColumnMajor;
   using LayoutOutput = cutlass::layout::RowMajor;
 
+#if CUDA_ARCH >= 800
   using EpilogueOp = cutlass::epilogue::thread::LinearCombinationRelu<
       ElementOutput, // <- data type of output matrix
       128 / cutlass::sizeof_bits<
@@ -429,6 +481,22 @@ torch::Tensor linear_relu_a8_w8_b8_o8(torch::Tensor input,  // INT8
       cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<16, 8, 32>,
       EpilogueOp, cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
       3>;
+#elif CUDA_ARCH >= 700
+  using EpilogueOp = cutlass::epilogue::thread::LinearCombinationRelu<
+      ElementOutput, 1, ElementAccumulator, ElementComputeEpilogue>;
+  using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
+      cutlass::arch::OpClassSimt, cutlass::arch::Sm70,
+      ElementInputA, ElementInputB, ElementOutput, ElementAccumulator>;
+  using Gemm = cutlass::gemm::device::Gemm<
+      int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
+      ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
+      cutlass::arch::OpClassSimt, cutlass::arch::Sm70,
+      DefaultGemmCfg::ThreadblockShape, DefaultGemmCfg::WarpShape,
+      DefaultGemmCfg::InstructionShape,
+      EpilogueOp>;
+#else
+  #error "Unsupported cuda arch"
+#endif
 
   auto input_size = cutlass::MatrixCoord(M, K);
   auto weight_size = cutlass::MatrixCoord(K, N);

--- a/torch_int/kernels/linear.cu
+++ b/torch_int/kernels/linear.cu
@@ -44,17 +44,19 @@ torch::Tensor linear_a8_w8_b32_o32(torch::Tensor input,  // INT8
           cutlass::epilogue::thread::ScaleType::NoBetaScaling>,
       cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
 #elif CUDA_ARCH >= 750
+  using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75,
+      ElementInputA, ElementInputB, ElementOutput, ElementAccumulator>;
   using Gemm = cutlass::gemm::device::Gemm<
       int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
       ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
       cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75,
-      cutlass::gemm::GemmShape<256, 128, 64>,
-      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<8, 8, 16>,
+      DefaultGemmCfg::ThreadblockShape, DefaultGemmCfg::WarpShape,
+      DefaultGemmCfg::InstructionShape,
       cutlass::epilogue::thread::LinearCombination<
           ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
           ElementAccumulator, ElementComputeEpilogue,
-          cutlass::epilogue::thread::ScaleType::NoBetaScaling>,
-      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 2>;
+          cutlass::epilogue::thread::ScaleType::NoBetaScaling>>;
 #elif CUDA_ARCH >= 700
   using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
       cutlass::arch::OpClassSimt, cutlass::arch::Sm70,
@@ -172,13 +174,7 @@ torch::Tensor linear_a8_w8_b32_o32_with_scaling(torch::Tensor input,  // INT8
   using Gemm = cutlass::gemm::device::Gemm<
       int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
       ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
-      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75,
-      cutlass::gemm::GemmShape<256, 128, 64>,
-      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<8, 8, 16>,
-      cutlass::epilogue::thread::LinearCombination<
-          ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
-          ElementAccumulator, ElementComputeEpilogue>,
-      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 2>;
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75>;
 #elif CUDA_ARCH >= 700
   using Gemm = cutlass::gemm::device::Gemm<
       int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
@@ -282,16 +278,18 @@ torch::Tensor linear_a8_w8_bfp32_ofp32(torch::Tensor input,  // INT8
           ElementAccumulator, ElementComputeEpilogue>,
       cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 3>;
 #elif CUDA_ARCH >= 750
+  using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75,
+      ElementInputA, ElementInputB, ElementOutput, ElementAccumulator>;
   using Gemm = cutlass::gemm::device::Gemm<
       int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
       ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
       cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75,
-      cutlass::gemm::GemmShape<256, 128, 64>,
-      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<8, 8, 16>,
+      DefaultGemmCfg::ThreadblockShape, DefaultGemmCfg::WarpShape,
+      DefaultGemmCfg::InstructionShape,
       cutlass::epilogue::thread::LinearCombination<
           ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
-          ElementAccumulator, ElementComputeEpilogue>,
-      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 2>;
+          ElementAccumulator, ElementComputeEpilogue>>;
 #elif CUDA_ARCH >= 700
   using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
       cutlass::arch::OpClassSimt, cutlass::arch::Sm70,
@@ -405,12 +403,7 @@ torch::Tensor linear_a8_w8_b8_o8(torch::Tensor input,  // INT8
   using Gemm = cutlass::gemm::device::Gemm<
       int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
       ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
-      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75,
-      cutlass::gemm::GemmShape<256, 128, 64>,
-      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<8, 8, 16>,
-      cutlass::epilogue::thread::FastLinearCombinationClamp<
-          ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value>,
-      cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, 2>;
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75>;
 #elif CUDA_ARCH >= 700
   using Gemm = cutlass::gemm::device::Gemm<
       int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
@@ -537,14 +530,16 @@ torch::Tensor linear_relu_a8_w8_b8_o8(torch::Tensor input,  // INT8
       ElementComputeEpilogue // <- data type for alpha in linear combination
                              // function
       >;
+  using DefaultGemmCfg = cutlass::gemm::device::DefaultGemmConfiguration<
+      cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75,
+      ElementInputA, ElementInputB, ElementOutput, ElementAccumulator>;
   using Gemm = cutlass::gemm::device::Gemm<
       int8_t, cutlass::layout::RowMajor, int8_t, cutlass::layout::ColumnMajor,
       ElementOutput, cutlass::layout::RowMajor, ElementAccumulator,
       cutlass::arch::OpClassTensorOp, cutlass::arch::Sm75,
-      cutlass::gemm::GemmShape<256, 128, 64>,
-      cutlass::gemm::GemmShape<64, 64, 64>, cutlass::gemm::GemmShape<8, 8, 16>,
-      EpilogueOp, cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
-      2>;
+      DefaultGemmCfg::ThreadblockShape, DefaultGemmCfg::WarpShape,
+      DefaultGemmCfg::InstructionShape,
+      EpilogueOp>;
 #elif CUDA_ARCH >= 700
   using EpilogueOp = cutlass::epilogue::thread::LinearCombinationRelu<
       ElementOutput, 1, ElementAccumulator, ElementComputeEpilogue>;


### PR DESCRIPTION
The existing code only runs on sm80 (A100). This PR adds support for sm70 (V100) and sm75 (T4).

The code passes the unit tests (`tests/test_bmm.py`, `tests/test_linear_kernel.py`) and end-to-end tests (`smoothquant_opt_real_int8_demo.ipynb`)

## V100, OPT-6.7B
```
Model size: 12700.031MB
FP16 accuracy: 0.798, per-sample latency: 105.986ms
Model size: 6555.157MB
SmoothQuant INT8 accuracy: 0.796, per-sample latency: 192.265ms
```
The slow speed is due to the lack of int8 tensor core on V100

## T4, OPT-6.7B
```
Model size: 12700.031MB
FP16 accuracy: 0.798, per-sample latency: 296.497ms
Model size: 6555.157MB
SmoothQuant INT8 accuracy: 0.796, per-sample latency: 225.479ms
```