### PR TITLE
Reduce alpha,beta unnecessary d2h

### DIFF
--- a/torch_int/nn/linear.py
+++ b/torch_int/nn/linear.py
@@ -27,6 +27,12 @@ class W8A8B8O8Linear(torch.nn.Module):
         self.register_buffer('a', torch.tensor(alpha))
         self.register_buffer('b', torch.tensor(beta))
 
+    def _apply(self, fn):
+        super()._apply(fn)
+        self.a = self.a.cpu()
+        self.b = self.b.cpu()
+        return self
+
     def to(self, *args, **kwargs):
         super().to(*args, **kwargs)
         self.weight = self.weight.to(*args, **kwargs)
@@ -70,6 +76,12 @@ class W8A8B8O8LinearReLU(torch.nn.Module):
             (1, self.out_features), dtype=torch.int8, requires_grad=False))
         self.register_buffer('a', torch.tensor(alpha))
         self.register_buffer('b', torch.tensor(beta))
+
+    def _apply(self, fn):
+        super()._apply(fn)
+        self.a = self.a.cpu()
+        self.b = self.b.cpu()
+        return self
 
     def to(self, *args, **kwargs):
         super().to(*args, **kwargs)
@@ -143,6 +155,12 @@ class W8A8B32O32Linear(torch.nn.Module):
         self.register_buffer('a', torch.tensor(alpha))
         self.register_buffer('b', torch.tensor(beta))
 
+    def _apply(self, fn):
+        super()._apply(fn)
+        self.a = self.a.cpu()
+        self.b = self.b.cpu()
+        return self
+
     def to(self, *args, **kwargs):
         super().to(*args, **kwargs)
         self.weight = self.weight.to(*args, **kwargs)
@@ -195,6 +213,7 @@ class W8A8BFP32OFP32Linear(torch.nn.Module):
     def _apply(self, fn):
         # prevent the bias from being converted to half
         super()._apply(fn)
+        self.a = self.a.cpu()
         self.bias = self.bias.to(torch.float32)
         return self
 


### PR DESCRIPTION
When I use this library, I find that there are many D2H copies of 4bytes, which occurs in self.a.item (), since a needs to be worn back to the cpu in the gpu memory to fetch the value, I fixed alpha and beta in the cpu after initialization. Fixed this bug, which improved by 6% in my test scence(It is not strictly compared, but the whole under the llm model.).
@Guangxuan-Xiao 